### PR TITLE
feat: Add constant for error code header to Go library

### DIFF
--- a/api_errors.go
+++ b/api_errors.go
@@ -24,6 +24,9 @@ type ApiError struct {
 	Payload    Payload
 }
 
+// Reponse header field that holds the API Error Code
+const ErrorCodeHeader = "X-Error-Code"
+
 var apiErrors = make(map[string]ApiError)
 
 //the line below (go:embed...) is a directive, not a comment!


### PR DESCRIPTION
## About

Add a constant that can be used to set `X-Error-Code` headers.