### PR TITLE
feat: add error 40320 matched_by_unverified_email and 40321 matched_by_unverified_phone

### DIFF
--- a/api-errors.json
+++ b/api-errors.json
@@ -345,11 +345,11 @@
     },
     "40320": {
         "short_message": "Matched By Unverified Email Address",
-        "long_message": "The content was sent to your Kivra by using email address as an identifier. In order to open the content in Kivra you first need to verify your email address."
+        "long_message": "The content was sent to your Kivra by using email address as an identifier. In order to open the content in Kivra you first need to verify your email address"
     },
     "40321": {
         "short_message": "Matched By Unverified Phone Number",
-        "long_message": "The content was sent to your Kivra by using phone number as an identifier. In order to open the content in Kivra you first need to verify your phone number."
+        "long_message": "The content was sent to your Kivra by using phone number as an identifier. In order to open the content in Kivra you first need to verify your phone number"
     },
     "40400": {
         "short_message": "Not Found",

--- a/api-errors.json
+++ b/api-errors.json
@@ -344,11 +344,11 @@
         "long_message": "Marketplace rejected the content of this request"
     },
     "40320": {
-        "short_message": "Matched by unverified email address",
+        "short_message": "Matched By Unverified Email Address",
         "long_message": "The content was sent to your Kivra by using email address as an identifier. In order to open the content in Kivra you first need to verify your email address."
     },
     "40321": {
-        "short_message": "Matched by unverified phone number",
+        "short_message": "Matched By Unverified Phone Number",
         "long_message": "The content was sent to your Kivra by using phone number as an identifier. In order to open the content in Kivra you first need to verify your phone number."
     },
     "40400": {

--- a/api-errors.json
+++ b/api-errors.json
@@ -343,6 +343,14 @@
         "short_message": "Rejected By Marketplace",
         "long_message": "Marketplace rejected the content of this request"
     },
+    "40320": {
+        "short_message": "Matched by unverified email address",
+        "long_message": "The content was sent to your Kivra by using email address as an identifier. In order to open the content in Kivra you first need to verify your email address."
+    },
+    "40321": {
+        "short_message": "Matched by unverified phone number",
+        "long_message": "The content was sent to your Kivra by using phone number as an identifier. In order to open the content in Kivra you first need to verify your phone number."
+    },
     "40400": {
         "short_message": "Not Found",
         "long_message": "The resource was not found at the given URI at this time"


### PR DESCRIPTION
It was suggested that these two error cases could be covered by these existing errors:

```
    "42202": {
        "short_message": "Unprocessable Entity",
        "long_message": "The user's email must be verified using OTP before making this request"
    },
    "42203": {
        "short_message": "Unprocessable Entity",
        "long_message": "The user's phone must be verified before making this request"
    },
```

While this is technically true, I reason that it makes more sense to add new error codes:

1. I think it is sensible to think of some of errors as user oriented and some of them as developer or integrator oriented. `matched_by_unverified_email` and `matched_by_unverified_phone` occurs when a user tries to open a content matched by either email address or phone number while the matching identifier is unverified, so they are directly user oriented. Those `Unprocessable Entity` errors seem to be more developer oriented.
1. We rely on Lokalise to show the localised error message to the user and we prefer the error message to be as specific and helpful as possible. It is not possible to override the error message for those `Unprocessable Entity` errors in Lokalise to serve our specific purpose.