### PR TITLE
chore: remove all specific forms errors

### DIFF
--- a/api-errors.json
+++ b/api-errors.json
@@ -187,14 +187,6 @@
         "short_message": "Invalid Label",
         "long_message": "The supplied labels does not match the required format"
     },
-    "40050": {
-        "short_message": "Form Response Error",
-        "long_message": "Error processing form response"
-    },
-    "40051": {
-        "short_message": "Content Form Creation Error",
-        "long_message": "Impossible to create content with a given form"
-    },
     "40052": {
         "short_message": "Malformed Header",
         "long_message": "One or more headers are malformed"
@@ -466,10 +458,6 @@
     "40922": {
         "short_message": "Consent Not Given",
         "long_message": "The user has not given consent for the requested service"
-    },
-    "40923": {
-        "short_message": "Forms Response Exists",
-        "long_message": "The form response has already been submitted"
     },
     "41000": {
         "short_message": "Gone",


### PR DESCRIPTION
All specific forms errors are now handled in forms. Specific errors here are no longer needed