### PR TITLE
refactor: Use `init` to initialize Go package

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,13 @@ Add `kivra-api-errors` as a dependency to your project:
 go get github.com/kivra/kivra-api-errors
 ```
 
-Call the `Load` function on application startup to load error definitions
-from disk. Afterwards, use the `FromCode` function to expand an error
-code to an `ApiError`:
+Use the `FromCode` function to expand an error code to an `ApiError`:
 
 ```go
 import (
 	apiErrors "github.com/kivra/kivra-api-errors"
 )
 
-apiErrors.Load()
 apiError, ok := apiErrors.FromCode("40001")
 ```
 

--- a/api_errors_test.go
+++ b/api_errors_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestGetErrorOK(t *testing.T) {
-	Load()
 	apiError, ok := FromCode("40000")
 
 	if !ok {
@@ -33,7 +32,6 @@ func TestGetErrorOK(t *testing.T) {
 }
 
 func TestDefaultFallbackExists(t *testing.T) {
-	Load()
 	_, ok := FromCode(Fallback)
 
 	if !ok {
@@ -42,7 +40,6 @@ func TestDefaultFallbackExists(t *testing.T) {
 }
 
 func TestFromStatusorFallback(t *testing.T) {
-	Load()
 	apiError := FromStatusOrFallback(400)
 
 	if apiError.Payload.Code != "40000" {
@@ -51,7 +48,6 @@ func TestFromStatusorFallback(t *testing.T) {
 }
 
 func TestReturnFallback(t *testing.T) {
-	Load()
 	apiError := FromCodeOrFallback("60000")
 
 	if apiError.Payload.Code != Fallback {
@@ -60,7 +56,6 @@ func TestReturnFallback(t *testing.T) {
 }
 
 func TestUnknownCode(t *testing.T) {
-	Load()
 	_, ok := FromCode("60000")
 
 	if ok {


### PR DESCRIPTION
## About

Use `init` function to initialize `Go` package -> no need to call `Load()`
https://go.dev/doc/effective_go#init