### PR TITLE
feat: allow (visually) exporting the list of known API error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,21 +130,13 @@ Run the linter to validate the error definitions in [`api-errors.json`](./api-er
 
 ## Export for use in `developer.kivra.com`
 
-A helper function is made available to allow copy-pasting the entire list for
+A `util` script is made available to allow copy-pasting the entire list for
 acceptance in <https://developer.kivra.com>.
 
-### Erlang
-
-Boot up an Erlang shell
+For this you need to have [`jq`](https://github.com/jqlang/jq#installation) installed.
 
 ```console
-rebar3 shell
-```
-
-Call the `kivra_api_errors:to_developer_kivra_com/0` function:
-
-```erlang
-kivra_api_errors:to_developer_kivra_com().
+./util/to-developer.kivra.com.sh
 ```
 
 Whatever is between `<copy-paste>` and `</copy-paste>` is deemed usable

--- a/README.md
+++ b/README.md
@@ -127,3 +127,25 @@ The following message contains the same information, but is more concise:
 Run the linter to validate the error definitions in [`api-errors.json`](./api-errors.json):
 
     make lint
+
+## Export for use in `developer.kivra.com`
+
+A helper function is made available to allow copy-pasting the entire list for
+acceptance in <https://developer.kivra.com>.
+
+### Erlang
+
+Boot up an Erlang shell
+
+```console
+rebar3 shell
+```
+
+Call the `kivra_api_errors:to_developer_kivra_com/0` function:
+
+```erlang
+kivra_api_errors:to_developer_kivra_com().
+```
+
+Whatever is between `<copy-paste>` and `</copy-paste>` is deemed usable
+(YML-formatted) in <https://developer.kivra.com>.

--- a/erlang/kivra_api_errors.erl
+++ b/erlang/kivra_api_errors.erl
@@ -5,8 +5,7 @@
 -export([
   load/0,
   load/1,
-  from_code/1, from_code/2, from_code/3,
-  to_developer_kivra_com/0
+  from_code/1, from_code/2, from_code/3
 ]).
 
 %%%_* Types ===================================================================
@@ -37,26 +36,6 @@ load(Config) ->
     Error ->
       Error
   end.
-
--spec to_developer_kivra_com() -> ok.
-to_developer_kivra_com() ->
-  ErrorsFile = filename:join([code:priv_dir(?MODULE), <<"api-errors.json">>]),
-  {ok, ErrorsAsJSON} = file:read_file(ErrorsFile),
-  Errors = jiffy:decode(ErrorsAsJSON, [return_maps]),
-  ErrorsList = maps:to_list(Errors),
-  SortedErrorsList = lists:sort(fun ({CodeLeft, _}, {CodeRight, _}) -> CodeLeft < CodeRight end, ErrorsList),
-
-  io:format("Copy-paste to developer.kivra.com's swagger.yml~n"),
-  io:format("<copy-paste>~n"),
-  io:format("    | Code | Short Message | Long Message |~n"),
-  io:format("    | ---- | ------------- | ------------ |~n"),
-  lists:foreach(
-    fun ({Code, #{<<"short_message">> := ShortMessage, <<"long_message">> := LongMessage}}) ->
-      io:format("    | ~ts | ~ts | ~ts |~n", [Code, ShortMessage, LongMessage])
-    end,
-    SortedErrorsList
-  ),
-  io:format("</copy-paste>~n").
 
 -spec from_code(binary() | pos_integer()) -> {ok, {status_code(), payload_map() | payload_kv()}} | {error, notfound}.
 from_code(ErrorCode) when is_integer(ErrorCode) ->

--- a/util/to-developer.kivra.com.sh
+++ b/util/to-developer.kivra.com.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if ! command -v jq &>/dev/null; then
+  echo "You need 'jq' to run this script."
+  exit 1
+fi
+
+echo "Copy-paste to developer.kivra.com's swagger.yml"
+echo "<copy-paste>"
+echo "    | Code | Short Message | Long Message |"
+echo "    | ---- | ------------- | ------------ |"
+jq -r 'to_entries | sort_by(.key) | .[] | "    | \(.key) | \(.value.short_message) | \(.value.long_message) |"' <api-errors.json
+echo "</copy-paste>"


### PR DESCRIPTION
The goal, as stated in the change, is to easy copy-pasting to developer.kivra.com, thus reducing the chance of inconsistency.

## Further considerations

The added function ~could be~ is a Bash script. ~or something else, more generic. I used Erlang because that's what was in front of me.~