### PR TITLE
chore: Pull jiffy from hex

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 
 {src_dirs, ["erlang"]}.
 
-{deps, [{jiffy, {git, "git@github.com:kivra/jiffy.git", {tag, "1.1.1"}}}]}.
+{deps, [{jiffy, "~> 1.1"}]}.
 
 {shell, [{apps, [kivra_api_errors]}]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,8 @@
-[{<<"jiffy">>,
-  {git,"git@github.com:kivra/jiffy.git",
-       {ref,"9ea1b35b6e60ba21dfd4adbd18e7916a831fd7d4"}},
-  0}].
+{"1.2.0",
+[{<<"jiffy">>,{pkg,<<"jiffy">>,<<"1.1.1">>},0}]}.
+[
+{pkg_hash,[
+ {<<"jiffy">>, <<"ACA10F47AA91697BF24AB9582C74E00E8E95474C7EF9F76D4F1A338D0F5DE21B">>}]},
+{pkg_hash_ext,[
+ {<<"jiffy">>, <<"62E1F0581C3C19C33A725C781DFA88410D8BFF1BBAFC3885A2552286B4785C4C">>}]}
+].


### PR DESCRIPTION
## About

Pull `jiffy` from hex.pm, mostly to avoid version conflicts in Elixir. 