### PR TITLE
no-release(fix): workflow concurrent execution conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
> ⚠️ **Disclaimer** ⚠️ this is a Creative Friday initiative. A prior discussion around it might have not happened.

# Motivation

Prevent errors for subsequent "merges", e.g. you may want to validate a given CI before moving on to the next one.

# Description

I'm under the impression we want:

1. to not allow concurrency for feature branches by cancelling current runs
2. to not allow concurrency in release branches by making sure we run one workflow at a time

# Further considerations

An undesired consequence of this change is that releases will be done in sequence so the process might take longer. On the other hand, it's also less error prone.