### PR TITLE
no-release(fix): act on GHA CI constraint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,11 @@ jobs:
 
     - name: Run Erlang Tests 🏃🏾
       shell: bash
-      run: make test-erl
+      run: |
+        # Since we can't force CI to run after pushing rebar.lock
+        # we remove it to make sure we test over rebar.config
+        rm -f rebar.lock
+        make test-erl
 
     - name: Run Go Tests 🏃🏽‍♀️
       shell: bash


### PR DESCRIPTION
# Motivation

Overcome a CI constraint.

# Description

Since the push in the workflow won't trigger a new CI run, we make sure the tests are done in an `unlocked` mode, as per `rebar.config`. At the end of the run we restore sanity by upgrading `rebar.lock`.