### PR TITLE
fix: Remove `release` dependency on `build`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'no-release:') == false
-    needs: build
     runs-on: ubuntu-24.04
     steps:
     - name: Bump version and push tag


### PR DESCRIPTION
# Motivation

Recent changes brought this to light.

# Description

It is my assumption, at this moment, that the workflow is the following:

1. create a pull request
2. `build` runs in feature branch
3. approve + merge pull request
4. `release` runs in the main branch

I can't figure out why `release` would `need` `build`, in that case, but I'm lifting that restriction, for now.