### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 ---
 name: ci
 permissions:
-  contents: read
+  contents: write
 
 on:
   # for feature branches and releases

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 ---
 name: ci
+permissions:
+  contents: read
 
 on:
   # for feature branches and releases
@@ -12,6 +14,9 @@ concurrency:
 jobs:
   build:
     if: github.ref != 'refs/heads/main'
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -79,6 +84,8 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'no-release:') == false
+    permissions:
+      contents: write
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ concurrency:
 jobs:
   build:
     if: github.ref != 'refs/heads/main'
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -84,8 +81,6 @@ jobs:
 
   release:
     if: github.ref == 'refs/heads/main' && startsWith(github.event.head_commit.message, 'no-release:') == false
-    permissions:
-      contents: write
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/kivra/kivra-api-errors/security/code-scanning/7](https://github.com/kivra/kivra-api-errors/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the root of the workflow and to individual jobs where necessary. This block will explicitly define the minimal permissions required for the workflow and its jobs. For example:
- The `build` job will require `contents: read` for accessing the repository contents and `pull-requests: write` for operations related to pull requests.
- The `release` job will require `contents: read` and `contents: write` for creating tags and releases.

This ensures that the `GITHUB_TOKEN` has only the permissions necessary for each job, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
