### PR TITLE
feat(fi): add 50401 "Polling Timeout"

### DIFF
--- a/api-errors.json
+++ b/api-errors.json
@@ -711,6 +711,10 @@
         "short_message": "Gateway Timeout",
         "long_message": "Gateway Timeout"
     },
+    "50401": {
+        "short_message": "Payment Polling Timeout",
+        "long_message": "Payment provider did not return a final status in time"
+    },
     "50500": {
         "short_message": "HTTP Version Not Supported",
         "long_message": "HTTP Version Not Supported"

--- a/api-errors.json
+++ b/api-errors.json
@@ -712,8 +712,8 @@
         "long_message": "Gateway Timeout"
     },
     "50401": {
-        "short_message": "Payment Polling Timeout",
-        "long_message": "Payment provider did not return a final status in time"
+        "short_message": "Polling Timeout",
+        "long_message": "Polling Timeout"
     },
     "50500": {
         "short_message": "HTTP Version Not Supported",


### PR DESCRIPTION
Initially phrased as "Payment Polling Timeout" since it was meant for an error case in Nello Pay. After consideration, I decided to make it more generic to represent timeout in any polling process. Since the context from which this error is returned is usually clear (whether it's about payments or something else), instead of having `x_polling_error`, `y_polling_error`, `z_polling_error`, I think it's better to make it a generic error.