### PR TITLE
chore: PE-7576 UPB-214 drop jiffy

### DIFF
--- a/erlang/kivra_api_errors.app.src
+++ b/erlang/kivra_api_errors.app.src
@@ -4,8 +4,7 @@
   {registered, []},
   {applications,
    [kernel,
-    stdlib,
-    jiffy
+    stdlib
    ]},
   {env,[]},
   {modules, []},

--- a/erlang/kivra_api_errors.erl
+++ b/erlang/kivra_api_errors.erl
@@ -33,7 +33,7 @@ load(Config) ->
         HTTPStatus = binary_to_integer(binary:part(Code, 0, 3)),
         Payload    = format(LongShort#{<<"code">> => Code}, ReturnMaps),
         persistent_term:put(key(Code), {HTTPStatus, Payload})
-      end, ok, jiffy:decode(Json, [return_maps]));
+      end, ok, json:decode(Json));
     Error ->
       Error
   end.

--- a/rebar.config
+++ b/rebar.config
@@ -8,9 +8,11 @@
            , warnings_as_errors
            ]}.
 
+{minimum_otp_vsn, "27.0"}.
+
 {src_dirs, ["erlang"]}.
 
-{deps, [{jiffy, "2.0.2"}]}.
+{deps, []}.
 
 {shell, [{apps, [kivra_api_errors]}]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,1 @@
-{"1.2.0",
-[{<<"jiffy">>,{pkg,<<"jiffy">>,<<"2.0.2">>},0}]}.
-[
-{pkg_hash,[
- {<<"jiffy">>, <<"5586481424BA9D30F5603D5245A3F00C74AA586B1BB1A56CACB812BBF9CBC0FD">>}]},
-{pkg_hash_ext,[
- {<<"jiffy">>, <<"67676E13C450BDCFACF224119C6435260B9A7EEF7B1681B4131D0193A839F9D4">>}]}
-].
+[].


### PR DESCRIPTION
**Why**

**Risk reduction**

jiffy is a NIF, which is the most expensive kind of dependency we can carry:
* a bug in a NIF doesn't crash a process, it crashes the whole VM - a JSON parser shouldn't hold that power

Since OTP 27, the stdlib json module does the same job, is maintained as part of OTP itself, and gets tested with every OTP release we adopt. The dependency no longer pays for what it costs.

**Maintenance cost**

We're also trying to reduce maintenance cost, since jiffy:
* requires a C toolchain in every build environment (bigger Docker build stages, slower builds, occasional breakage on OTP upgrades, ...)
* is a third-party supply-chain surface with its own release cadence
* releases impose extra GitHub Actions credits, for us, via Renovate churn